### PR TITLE
Automatically clear the default values of the input boxes

### DIFF
--- a/src/components/Poker/CreateGame/CreateGame.test.tsx
+++ b/src/components/Poker/CreateGame/CreateGame.test.tsx
@@ -44,6 +44,17 @@ describe('CreateGame component', () => {
     expect(userName).toHaveValue('user name');
   });
 
+  it('should empty inputs when clicked', () => {
+    render(<CreateGame />);
+    const sessionName = screen.getByPlaceholderText('Enter a session name');
+    const userName = screen.getByPlaceholderText('Enter your name');
+    userEvent.click(sessionName);
+    userEvent.click(userName);
+
+    expect(sessionName).toHaveValue('');
+    expect(userName).toHaveValue('');
+  });
+
   it('should be able to create new session', async () => {
     render(<CreateGame />);
     const sessionName = screen.getByPlaceholderText('Enter a session name');

--- a/src/components/Poker/CreateGame/CreateGame.tsx
+++ b/src/components/Poker/CreateGame/CreateGame.tsx
@@ -28,8 +28,10 @@ const userNameConfig: Config = {
 
 export const CreateGame = () => {
   const history = useHistory();
-  const [gameName, setGameName] = useState(uniqueNamesGenerator(gameNameConfig));
-  const [createdBy, setCreatedBy] = useState(uniqueNamesGenerator(userNameConfig));
+  let defaultGameName = uniqueNamesGenerator(gameNameConfig);
+  let defaultCreatorName = uniqueNamesGenerator(userNameConfig);
+  const [gameName, setGameName] = useState(defaultGameName);
+  const [createdBy, setCreatedBy] = useState(defaultCreatorName);
   const [gameType, setGameType] = useState(GameType.Fibonacci);
   const [hasDefaults, setHasDefaults] = useState({ game: true, name: true });
 
@@ -45,20 +47,8 @@ export const CreateGame = () => {
     history.push(`/game/${newGameId}`);
   };
 
-  const emptyGameName = () => {
-    if (hasDefaults.game) {
-      setGameName('');
-      hasDefaults.game = false;
-      setHasDefaults(hasDefaults);
-    }
-  };
-  const emptyCreatorName = () => {
-    if (hasDefaults.name) {
-      setCreatedBy('');
-      hasDefaults.name = false;
-      setHasDefaults(hasDefaults);
-    }
-  };
+  const emptyGameName = () => { defaultGameName = ''; };
+  const emptyCreatorName = () => { defaultCreatorName = ''; };
 
   return (
     <Grow in={true} timeout={1000}>
@@ -76,7 +66,7 @@ export const CreateGame = () => {
               id='filled-required'
               label='Session Name'
               placeholder='Enter a session name'
-              value={gameName}
+              defaultValue={gameName}
               onClick={() => emptyGameName()}
               variant='outlined'
               onChange={(event: ChangeEvent<HTMLInputElement>) => setGameName(event.target.value)}
@@ -87,7 +77,7 @@ export const CreateGame = () => {
               id='filled-required'
               label='Your Name'
               placeholder='Enter your name'
-              value={createdBy}
+              defaultValue={createdBy}
               onClick={() => emptyCreatorName()}
               variant='outlined'
               onChange={(event: ChangeEvent<HTMLInputElement>) => setCreatedBy(event.target.value)}

--- a/src/components/Poker/CreateGame/CreateGame.tsx
+++ b/src/components/Poker/CreateGame/CreateGame.tsx
@@ -28,10 +28,8 @@ const userNameConfig: Config = {
 
 export const CreateGame = () => {
   const history = useHistory();
-  let defaultGameName = uniqueNamesGenerator(gameNameConfig);
-  let defaultCreatorName = uniqueNamesGenerator(userNameConfig);
-  const [gameName, setGameName] = useState(defaultGameName);
-  const [createdBy, setCreatedBy] = useState(defaultCreatorName);
+  const [gameName, setGameName] = useState(uniqueNamesGenerator(gameNameConfig));
+  const [createdBy, setCreatedBy] = useState(uniqueNamesGenerator(userNameConfig));
   const [gameType, setGameType] = useState(GameType.Fibonacci);
   const [hasDefaults, setHasDefaults] = useState({ game: true, name: true });
 
@@ -47,8 +45,20 @@ export const CreateGame = () => {
     history.push(`/game/${newGameId}`);
   };
 
-  const emptyGameName = () => { defaultGameName = ''; };
-  const emptyCreatorName = () => { defaultCreatorName = ''; };
+  const emptyGameName = () => {
+    if (hasDefaults.game) {
+      setGameName('');
+      hasDefaults.game = false;
+      setHasDefaults(hasDefaults);
+    }
+  };
+  const emptyCreatorName = () => {
+    if (hasDefaults.name) {
+      setCreatedBy('');
+      hasDefaults.name = false;
+      setHasDefaults(hasDefaults);
+    }
+  };
 
   return (
     <Grow in={true} timeout={1000}>
@@ -66,7 +76,7 @@ export const CreateGame = () => {
               id='filled-required'
               label='Session Name'
               placeholder='Enter a session name'
-              defaultValue={gameName}
+              value={gameName}
               onClick={() => emptyGameName()}
               variant='outlined'
               onChange={(event: ChangeEvent<HTMLInputElement>) => setGameName(event.target.value)}
@@ -77,7 +87,7 @@ export const CreateGame = () => {
               id='filled-required'
               label='Your Name'
               placeholder='Enter your name'
-              defaultValue={createdBy}
+              value={createdBy}
               onClick={() => emptyCreatorName()}
               variant='outlined'
               onChange={(event: ChangeEvent<HTMLInputElement>) => setCreatedBy(event.target.value)}

--- a/src/components/Poker/CreateGame/CreateGame.tsx
+++ b/src/components/Poker/CreateGame/CreateGame.tsx
@@ -76,7 +76,7 @@ export const CreateGame = () => {
               id='filled-required'
               label='Session Name'
               placeholder='Enter a session name'
-              value={gameName}
+              value={gameName || ''}
               onClick={() => emptyGameName()}
               variant='outlined'
               onChange={(event: ChangeEvent<HTMLInputElement>) => setGameName(event.target.value)}
@@ -87,7 +87,7 @@ export const CreateGame = () => {
               id='filled-required'
               label='Your Name'
               placeholder='Enter your name'
-              value={createdBy}
+              value={createdBy || ''}
               onClick={() => emptyCreatorName()}
               variant='outlined'
               onChange={(event: ChangeEvent<HTMLInputElement>) => setCreatedBy(event.target.value)}

--- a/src/components/Poker/CreateGame/CreateGame.tsx
+++ b/src/components/Poker/CreateGame/CreateGame.tsx
@@ -31,6 +31,7 @@ export const CreateGame = () => {
   const [gameName, setGameName] = useState(uniqueNamesGenerator(gameNameConfig));
   const [createdBy, setCreatedBy] = useState(uniqueNamesGenerator(userNameConfig));
   const [gameType, setGameType] = useState(GameType.Fibonacci);
+  const [hasDefaults, setHasDefaults] = useState({ game: true, name: true });
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -42,6 +43,21 @@ export const CreateGame = () => {
     };
     const newGameId = await addNewGame(game);
     history.push(`/game/${newGameId}`);
+  };
+
+  const emptyGameName = () => {
+    if (hasDefaults.game) {
+      setGameName('');
+      hasDefaults.game = false;
+      setHasDefaults(hasDefaults);
+    }
+  };
+  const emptyCreatorName = () => {
+    if (hasDefaults.name) {
+      setCreatedBy('');
+      hasDefaults.name = false;
+      setHasDefaults(hasDefaults);
+    }
   };
 
   return (
@@ -60,7 +76,8 @@ export const CreateGame = () => {
               id='filled-required'
               label='Session Name'
               placeholder='Enter a session name'
-              defaultValue={gameName}
+              value={gameName}
+              onClick={() => emptyGameName()}
               variant='outlined'
               onChange={(event: ChangeEvent<HTMLInputElement>) => setGameName(event.target.value)}
             />
@@ -70,7 +87,8 @@ export const CreateGame = () => {
               id='filled-required'
               label='Your Name'
               placeholder='Enter your name'
-              defaultValue={createdBy}
+              value={createdBy}
+              onClick={() => emptyCreatorName()}
               variant='outlined'
               onChange={(event: ChangeEvent<HTMLInputElement>) => setCreatedBy(event.target.value)}
             />


### PR DESCRIPTION
This annoyed me sufficiently that after some fiddling, it now automagically clears the default values from the game/player name input boxes when clicked/tapped. Plus, the test for the new functionality.

Note: In Material UI, the `defaultValue` prop for an input is only for unmanaged inputs, but since there's an onchange listener this is not an unmanaged input, hence using `value`