### PR TITLE
Adding timer feature

### DIFF
--- a/src/components/Poker/GameController/GameController.css
+++ b/src/components/Poker/GameController/GameController.css
@@ -29,6 +29,8 @@
   padding-left: 20px;
   border-bottom: 1px solid var(--color-primary);
   font-weight: bold;
+  min-height: 40px;
+  align-items: center;
 }
 
 .GameControllerButtonContainer {
@@ -41,7 +43,7 @@
 .GameControllerButton {
   display: flex;
   border-radius: 50%;
-  background-color:  var(--color-background);
+  background-color: var(--color-background);
 }
 .GameControllerButton:hover {
   box-shadow: rgb(171 207 248) 0px 0px 0px 6px;
@@ -50,6 +52,8 @@
 .GameControllerCardHeaderAverageContainer {
   display: flex;
   flex-direction: row;
+  justify-content: center;
+  align-items: center;
   margin: 3px;
   padding-left: 30px;
 }
@@ -60,9 +64,11 @@
   color: var(--color-warning);
   font-weight: bold;
 }
-
-
+.GameControllerGameStatus {
+  padding-right: 5px;
+}
 .MuiCardHeader-action {
   margin: 0;
   padding-right: 5px;
+  align-self: auto;
 }

--- a/src/components/Poker/GameController/GameController.test.tsx
+++ b/src/components/Poker/GameController/GameController.test.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable testing-library/no-node-access */
+/* eslint-disable testing-library/no-container */
 import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { Game, GameType } from '../../../types/game';
 import { Status } from '../../../types/status';
 import { GameController } from './GameController';

--- a/src/components/Poker/GameController/GameController.tsx
+++ b/src/components/Poker/GameController/GameController.tsx
@@ -15,7 +15,7 @@ import LinkIcon from '@material-ui/icons/Link';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import DeleteOutlined from '@material-ui/icons/DeleteForeverTwoTone';
 import Alert from '@material-ui/lab/Alert';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { finishGame, resetGame, removeGame } from '../../../service/games';
 import { Game, GameType } from '../../../types/game';
@@ -58,6 +58,10 @@ export const GameController: React.FC<GameControllerProps> = ({ game, currentPla
     window.location.href = '/';
   };
 
+  const onTimerEndCallBack = useCallback(()=>{
+    finishGame(game.id);
+  },[game.id])
+
   return (
     <Grow in={true} timeout={2000}>
       <div className='GameController'>
@@ -74,9 +78,7 @@ export const GameController: React.FC<GameControllerProps> = ({ game, currentPla
                   <TimerProgress
                     timerValue={timerValue ?? 0}
                     startTimer={isTimmerRunnig}
-                    onTimerEnd={() => {
-                      finishGame(game.id);
-                    }}
+                    onTimerEnd={onTimerEndCallBack}
                   ></TimerProgress>
                 ) : null}
                 {game.gameType !== GameType.TShirt &&

--- a/src/components/Poker/GameController/Timer/Timer.css
+++ b/src/components/Poker/GameController/Timer/Timer.css
@@ -1,0 +1,20 @@
+.timerPopoverContainer {
+  display: flex;
+  flex-direction: row;
+  column-gap: 10px;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--color-background-secondary);
+  padding: 10px;
+}
+
+.timerInput {
+  width: 5rem;
+  input {
+    text-align: center;
+  }
+}
+
+.seconds-label {
+  font-size: small;
+}

--- a/src/components/Poker/GameController/Timer/Timer.tsx
+++ b/src/components/Poker/GameController/Timer/Timer.tsx
@@ -1,0 +1,181 @@
+import {
+  IconButton,
+  Popper,
+  Fade,
+  Paper,
+  ClickAwayListener,
+  Input,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+import { green, grey } from '@material-ui/core/colors';
+import { useRef, useState } from 'react';
+import TimerIcon from '@material-ui/icons/Timer';
+import './Timer.css';
+
+export const TimerController: React.FC<{
+  isTimer: boolean;
+  setIsTimer: (timer: boolean) => void;
+  timerValue: number | null;
+  setTimerValue: (time: string) => void;
+}> = ({ isTimer, setIsTimer, timerValue, setTimerValue }) => {
+  const classes = useStyles();
+  const [arrowRef, setArrowRef] = useState<HTMLElement | null>(null);
+  const inputRef = useRef<HTMLInputElement>();
+
+  const [open, setOpen] = useState(false);
+  const [popoverAnchor, setPopoverAnchor] = useState(null);
+
+  const handlePopoverChange = (event: any) => {
+    if (isTimer) {
+      setIsTimer(false);
+      return;
+    }
+    setIsTimer(true);
+    const updatePopover = popoverAnchor ? null : event.currentTarget;
+    setPopoverAnchor(updatePopover);
+    setOpen(Boolean(updatePopover));
+    setTimeout(() => {
+      inputRef?.current?.focus();
+    }, 10);
+  };
+
+  const id = open ? 'spring-popper' : undefined;
+
+  return (
+    <div className='GameControllerButtonContainer'>
+      <div className='GameControllerButton' onClick={handlePopoverChange} data-testid='timer-pop'>
+        <IconButton data-testid='timer-button'>
+          <TimerIcon fontSize='large' style={{ color: isTimer ? green[500] : grey[500] }} />
+        </IconButton>
+      </div>
+      <Popper
+        id={id}
+        open={open}
+        anchorEl={popoverAnchor}
+        placement='top'
+        transition
+        className={classes.popper}
+        modifiers={{
+          preventOverflow: {
+            enabled: true,
+            boundariesElement: 'window',
+          },
+          arrow: {
+            enabled: true,
+            element: arrowRef,
+          },
+        }}
+      >
+        {({ TransitionProps }) => (
+          <Fade {...TransitionProps} timeout={50}>
+            <Paper>
+              <ClickAwayListener
+                onClickAway={() => {
+                  setOpen(false);
+                  setPopoverAnchor(null);
+                  if (!timerValue) {
+                    setIsTimer(false);
+                  }
+                }}
+              >
+                <Paper className={classes.popoverRoot}>
+                  <span className={classes.arrow} ref={setArrowRef} />
+                  <div className='timerPopoverContainer'>
+                    <Input
+                      type='number'
+                      value={timerValue}
+                      className='timerInput'
+                      data-testid='timer-input'
+                      onChange={(e) => {
+                        setTimerValue(e.target.value);
+                      }}
+                      inputRef={inputRef}
+                    ></Input>
+                    <label className='seconds-label'>secs</label>
+                  </div>
+                </Paper>
+              </ClickAwayListener>
+            </Paper>
+          </Fade>
+        )}
+      </Popper>
+      <Typography variant='caption'>Timer</Typography>
+    </div>
+  );
+};
+
+const useStyles = makeStyles((theme) => {
+  return {
+    popoverRoot: {
+      backgroundColor: '#75a1de21',
+      maxWidth: 1000,
+    },
+    content: {
+      padding: theme.spacing(10),
+    },
+    popper: {
+      zIndex: 2000,
+      '&[x-placement*="bottom"] $arrow': {
+        top: 0,
+        left: 0,
+        marginTop: '-0.71em',
+        marginLeft: 4,
+        marginRight: 4,
+        '&::before': {
+          transformOrigin: '0 100%',
+        },
+      },
+      '&[x-placement*="top"] $arrow': {
+        bottom: 0,
+        left: 0,
+        marginBottom: '-0.71em',
+        marginLeft: 4,
+        marginRight: 4,
+        '&::before': {
+          transformOrigin: '100% 0',
+        },
+      },
+      '&[x-placement*="right"] $arrow': {
+        left: 0,
+        marginLeft: '-0.71em',
+        height: '1em',
+        width: '0.71em',
+        marginTop: 4,
+        marginBottom: 4,
+        '&::before': {
+          transformOrigin: '100% 100%',
+        },
+      },
+      '&[x-placement*="left"] $arrow': {
+        right: 0,
+        marginRight: '-0.71em',
+        height: '1em',
+        width: '0.71em',
+        marginTop: 4,
+        marginBottom: 4,
+        '&::before': {
+          transformOrigin: '0 0',
+        },
+      },
+    },
+    arrow: {
+      overflow: 'hidden',
+      position: 'absolute',
+      width: '1em',
+      height: '0.71em',
+      boxSizing: 'border-box',
+      color: '#75a1de21',
+      '&::before': {
+        content: '""',
+        margin: 'auto',
+        display: 'block',
+        width: '100%',
+        height: '100%',
+        boxShadow: theme.shadows[1],
+        backgroundColor: 'currentColor',
+        transform: 'rotate(45deg)',
+      },
+    },
+  };
+});

--- a/src/components/Poker/GameController/TimerProgress/TimerProgress.css
+++ b/src/components/Poker/GameController/TimerProgress/TimerProgress.css
@@ -1,0 +1,19 @@
+.green-progress {
+  color: lightgreen;
+}
+
+.red-progress {
+  color: red;
+}
+
+.custom-progress {
+  width: 30px !important;
+  height: 30px !important;
+}
+
+.progress-time-text {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  text-align: center;
+  padding: 3px;
+}

--- a/src/components/Poker/GameController/TimerProgress/TimerProgress.tsx
+++ b/src/components/Poker/GameController/TimerProgress/TimerProgress.tsx
@@ -38,7 +38,7 @@ export const TimerProgress: React.FC<TimerProgressProps> = ({
     return () => {
       if (timer) clearInterval(timer);
     };
-  }, [startTimer]);
+  }, [startTimer,onTimerEnd,milliseconds]);
 
   useEffect(() => {
     setProgress(timerValue * 1000);

--- a/src/components/Poker/GameController/TimerProgress/TimerProgress.tsx
+++ b/src/components/Poker/GameController/TimerProgress/TimerProgress.tsx
@@ -44,6 +44,7 @@ export const TimerProgress: React.FC<TimerProgressProps> = ({
     setProgress(timerValue * 1000);
   }, [timerValue]);
   const percentageProgress = (progress / milliseconds) * 100;
+  const progressLable = (progress / 1000).toFixed();
   return (
     <Box position='relative' display='inline-flex'>
       <CircularProgress
@@ -73,10 +74,10 @@ export const TimerProgress: React.FC<TimerProgressProps> = ({
           component='div'
           color='textSecondary'
           className='progress-time-text'
-          title={(progress / 1000).toFixed() + ' Seconds'}
+          title={progressLable + ' Seconds'}
           data-testid='timer-seconds'
         >
-          {(progress / 1000).toFixed()}s
+          {progressLable}s
         </Typography>
       </Box>
     </Box>

--- a/src/components/Poker/GameController/TimerProgress/TimerProgress.tsx
+++ b/src/components/Poker/GameController/TimerProgress/TimerProgress.tsx
@@ -1,0 +1,84 @@
+import { Box, CircularProgress, Typography } from '@material-ui/core';
+import { useEffect, useState } from 'react';
+import './TimerProgress.css';
+
+interface TimerProgressProps {
+  timerValue: number;
+  startTimer: boolean;
+  onTimerEnd: () => void;
+}
+
+export const TimerProgress: React.FC<TimerProgressProps> = ({
+  timerValue,
+  startTimer,
+  onTimerEnd,
+}) => {
+  const milliseconds = timerValue * 1000;
+  const [progress, setProgress] = useState(milliseconds);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (startTimer) {
+      setProgress(milliseconds);
+      timer = setInterval(() => {
+        setProgress((prevProgress: number) => {
+          const currentProgress = prevProgress - 1000;
+          if (prevProgress < 0 || prevProgress === 0) {
+            clearInterval(timer);
+            setProgress(milliseconds);
+            onTimerEnd();
+          }
+          return currentProgress;
+        });
+      }, 1000);
+    } else {
+      setProgress(milliseconds);
+    }
+
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  }, [startTimer]);
+
+  useEffect(() => {
+    setProgress(timerValue * 1000);
+  }, [timerValue]);
+  const percentageProgress = (progress / milliseconds) * 100;
+  return (
+    <Box position='relative' display='inline-flex'>
+      <CircularProgress
+        variant='determinate'
+        value={percentageProgress}
+        className={`custom-progress ${
+          percentageProgress > 50
+            ? 'green-progress'
+            : percentageProgress > 25 || progress === 0
+            ? ''
+            : 'red-progress'
+        }`}
+      />
+      <Box
+        top={0}
+        left={0}
+        bottom={0}
+        right={0}
+        position='absolute'
+        display='flex'
+        alignItems='center'
+        justifyContent='center'
+        textOverflow=''
+      >
+        <Typography
+          variant='caption'
+          component='div'
+          color='textSecondary'
+          className='progress-time-text'
+          title={(progress / 1000).toFixed() + ' Seconds'}
+          data-testid='timer-seconds'
+        >
+          {(progress / 1000).toFixed()}s
+        </Typography>
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
📝 Description
This pull request adds a timer feature.
The timer can be enabled or disabled by the moderator. The timer automatically starts on clicking restart. The timer can be disabled anytime. Once the set time is over (only supported time seconds for now) will automatically reveal the voting

🛠️ Changes made
Added new components for showing timer progress and timer toggle button.
Modified gameController component to accommodate the timer toggle and timer progress controls.

🧪 Testing
Added unit tests to ensure the proper toggling of timer control.
Added unit tests for timer end reveal feature.

📸 Screenshots

![chrome-capture-2024-1-6](https://github.com/hellomuthu23/planning-poker/assets/31062212/2b5e9f77-7d59-4aa5-9e27-aa2784503fbf)


