### PR TITLE
Allow members to be moderator

### DIFF
--- a/src/components/Players/PlayerCard/PlayerCard.tsx
+++ b/src/components/Players/PlayerCard/PlayerCard.tsx
@@ -34,7 +34,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({ game, player, currentPla
         title={player.name}
         titleTypographyProps={{ variant: 'subtitle2', noWrap: true, title: player.name }}
         action={
-          isModerator(game.createdById, currentPlayerId) &&
+          isModerator(game.createdById, currentPlayerId, game.isAllowMembersToManageSession) &&
           player.id !== currentPlayerId && (
             <IconButton
               title='Remove'

--- a/src/components/Poker/CreateGame/CreateGame.test.tsx
+++ b/src/components/Poker/CreateGame/CreateGame.test.tsx
@@ -71,7 +71,39 @@ describe('CreateGame component', () => {
     expect(gamesService.addNewGame).toHaveBeenCalled();
 
     expect(gamesService.addNewGame).toHaveBeenCalledWith(
-      expect.objectContaining({ createdBy: 'Rock', gameType: 'Fibonacci', name: 'Marvels' }),
+      expect.objectContaining({
+        createdBy: 'Rock',
+        gameType: 'Fibonacci',
+        name: 'Marvels',
+        isAllowMembersToManageSession: false,
+      }),
+    );
+  });
+  it('should be able to create new session with Allow members to manage session', async () => {
+    render(<CreateGame />);
+    const sessionName = screen.getByPlaceholderText('Enter a session name');
+    userEvent.clear(sessionName);
+    userEvent.type(sessionName, 'Marvels');
+
+    const userName = screen.getByPlaceholderText('Enter your name');
+    userEvent.clear(userName);
+    userEvent.type(userName, 'Rock');
+
+    const allowMembersToManageSession = screen.getByText('Allow members to manage session');
+    userEvent.click(allowMembersToManageSession);
+
+    const createButton = screen.getByText('Create');
+    userEvent.click(createButton);
+
+    expect(gamesService.addNewGame).toHaveBeenCalled();
+
+    expect(gamesService.addNewGame).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdBy: 'Rock',
+        gameType: 'Fibonacci',
+        name: 'Marvels',
+        isAllowMembersToManageSession: true,
+      }),
     );
   });
   it('should be able to create new session of TShirt Sizing', async () => {

--- a/src/components/Poker/CreateGame/CreateGame.tsx
+++ b/src/components/Poker/CreateGame/CreateGame.tsx
@@ -4,6 +4,7 @@ import {
   CardActions,
   CardContent,
   CardHeader,
+  Checkbox,
   FormControlLabel,
   Grow,
   Radio,
@@ -35,6 +36,7 @@ export const CreateGame = () => {
   const [gameType, setGameType] = useState(GameType.Fibonacci);
   const [hasDefaults, setHasDefaults] = useState({ game: true, name: true });
   const [loading, setLoading] = useState(false);
+  const [allowMembersToManageSession, setAllowMembersToManageSession] = useState(false);
   const [customOptions, setCustomOptions] = React.useState(Array(10).fill(''));
   const [error, setError] = React.useState(false);
   const { t } = useTranslation();
@@ -56,6 +58,7 @@ export const CreateGame = () => {
       name: gameName,
       createdBy: createdBy,
       gameType: gameType,
+      isAllowMembersToManageSession: allowMembersToManageSession,
       cards: gameType === GameType.Custom ? getCustomCards(customOptions) : getCards(gameType),
       createdAt: new Date(),
     };
@@ -183,6 +186,16 @@ export const CreateGame = () => {
                 )}
               </>
             )}
+            <FormControlLabel
+              control={
+                <Checkbox
+                  color='primary'
+                  checked={allowMembersToManageSession}
+                  onChange={() => setAllowMembersToManageSession(!allowMembersToManageSession)}
+                />
+              }
+              label='Allow members to manage session'
+            />
           </CardContent>
           <CardActions className='CreateGameCardAction'>
             <Button

--- a/src/components/Poker/GameController/GameController.tsx
+++ b/src/components/Poker/GameController/GameController.tsx
@@ -80,7 +80,7 @@ export const GameController: React.FC<GameControllerProps> = ({ game, currentPla
             className='GameControllerCardTitle'
           ></CardHeader>
           <CardContent className='GameControllerCardContentArea'>
-            {isModerator(game.createdById, currentPlayerId) && (
+            {isModerator(game.createdById, currentPlayerId, game.isAllowMembersToManageSession) && (
               <>
                 <div className='GameControllerButtonContainer'>
                   <div className='GameControllerButton'>

--- a/src/components/Poker/RecentGames/RecentGames.tsx
+++ b/src/components/Poker/RecentGames/RecentGames.tsx
@@ -89,7 +89,11 @@ export const RecentGames = () => {
                       >
                         <TableCell>{recentGame.name}</TableCell>
                         <TableCell align='left'>{recentGame.createdBy}</TableCell>
-                        {isModerator(recentGame.createdById, getCurrentPlayerId(recentGame.id)) ? (
+                        {isModerator(
+                          recentGame.createdById,
+                          getCurrentPlayerId(recentGame.id),
+                          recentGame.isAllowMembersToManageSession,
+                        ) ? (
                           <TableCell align='center' onClick={(e) => e.stopPropagation()}>
                             <AlertDialog
                               title='Remove recent game'
@@ -103,7 +107,7 @@ export const RecentGames = () => {
                           <TableCell align='left'></TableCell>
                         )}
                       </TableRow>
-                    )
+                    ),
                 )}
               </TableBody>
             </Table>

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -7,6 +7,7 @@ export interface Game {
   average: number;
   gameStatus: Status;
   gameType?: GameType | GameType.Fibonacci;
+  isAllowMembersToManageSession?: boolean;
   cards: CardConfig[];
   createdBy: string;
   createdById: string;
@@ -18,6 +19,7 @@ export interface NewGame {
   name: string;
   gameType: string;
   cards: CardConfig[];
+  isAllowMembersToManageSession?: boolean;
   createdBy: string;
   createdAt: Date;
 }

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -11,6 +11,7 @@ export interface Player {
 export interface PlayerGame {
   id: string;
   name: string;
+  isAllowMembersToManageSession?: boolean;
   createdById: string;
   createdBy: string;
   playerId: string;

--- a/src/utils/isModerator.test.ts
+++ b/src/utils/isModerator.test.ts
@@ -1,0 +1,51 @@
+import { isModerator } from './isModerator';
+
+describe('isModerator', () => {
+  it('should return true if the currentPlayerId matches the moderatorId', () => {
+    const moderatorId = 'moderator123';
+    const currentPlayerId = 'moderator123';
+    const isAllowMembersToManageSession = false;
+
+    const result = isModerator(moderatorId, currentPlayerId, isAllowMembersToManageSession);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false if the currentPlayerId does not match the moderatorId', () => {
+    const moderatorId = 'moderator123';
+    const currentPlayerId = 'player456';
+    const isAllowMembersToManageSession = false;
+
+    const result = isModerator(moderatorId, currentPlayerId, isAllowMembersToManageSession);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if isAllowMembersToManageSession is false', () => {
+    const moderatorId = 'moderator123';
+    const currentPlayerId = 'player456';
+    const isAllowMembersToManageSession = false;
+
+    const result = isModerator(moderatorId, currentPlayerId, isAllowMembersToManageSession);
+
+    expect(result).toBe(false);
+  });
+  it('should return false if isAllowMembersToManageSession is undefined', () => {
+    const moderatorId = 'moderator123';
+    const currentPlayerId = 'player456';
+    const isAllowMembersToManageSession = undefined;
+
+    const result = isModerator(moderatorId, currentPlayerId, isAllowMembersToManageSession);
+
+    expect(result).toBe(false);
+  });
+  it('should return true if isAllowMembersToManageSession is true', () => {
+    const moderatorId = 'moderator123';
+    const currentPlayerId = 'moderator123';
+    const isAllowMembersToManageSession = true;
+
+    const result = isModerator(moderatorId, currentPlayerId, isAllowMembersToManageSession);
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/utils/isModerator.ts
+++ b/src/utils/isModerator.ts
@@ -1,3 +1,10 @@
-export const isModerator = (moderatorId: string, currentPlayerId: string | undefined) => {
+export const isModerator = (
+  moderatorId: string,
+  currentPlayerId: string | undefined,
+  isAllowMembersToManageSession: boolean | undefined,
+) => {
+  if (isAllowMembersToManageSession) {
+    return true;
+  }
   return moderatorId === currentPlayerId;
 };


### PR DESCRIPTION
Add Allow members to manage session feature 
- User can select `Allow members to manage session` option while creating new session and anyone who in the session can reveal cards, restart session, delete members as Moderator can do.
Fixes #92 


![image](https://github.com/hellomuthu23/planning-poker/assets/59234994/075ba67f-4faf-4314-b43d-80a0b76b1d55)
