### PR TITLE
fix: Modify fallbackLng default value

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -8,7 +8,8 @@ i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    fallbackLng: 'en-US',
+    fallbackLng: 'en',
+    fallbackNS: 'US',
     debug: false,
     react: {
       useSuspense: false,


### PR DESCRIPTION
# Issue

Bug with translation: https://github.com/hellomuthu23/planning-poker/issues/90


# Description
Fix default language and missing keys:
- Modify default value of `fallbackLng`
- Add default value for `fallbackNS`

### Before the fix
<img width="500" alt="image" src="https://github.com/user-attachments/assets/c0f36449-c273-45f1-aa64-4a84741f768f">

### After the fix
<img width="500" alt="image" src="https://github.com/user-attachments/assets/de20b795-61b0-4c82-92b1-6a42fc3a3de1">



