### PR TITLE
fix: Stick GameController to the left and adjust button styles

### DIFF
--- a/src/components/Poker/GameController/GameController.css
+++ b/src/components/Poker/GameController/GameController.css
@@ -2,6 +2,8 @@
   display: flex;
   justify-content: center;
   margin-bottom: 20px;
+  position: sticky;
+  left: 0;
 }
 
 .GameControllerCard {
@@ -41,7 +43,7 @@
 .GameControllerButton {
   display: flex;
   border-radius: 50%;
-  background-color:  var(--color-background);
+  background-color: var(--color-background);
 }
 .GameControllerButton:hover {
   box-shadow: rgb(171 207 248) 0px 0px 0px 6px;
@@ -60,7 +62,6 @@
   color: var(--color-warning);
   font-weight: bold;
 }
-
 
 .MuiCardHeader-action {
   margin: 0;


### PR DESCRIPTION
## 📝 Description
- Adding sticky display and left position for GameController when the amount of players exceeds the screen's size

## 📹 Screen Recording
https://github.com/user-attachments/assets/4da6e106-9a6f-4ba2-9f67-673dc2657f2f

