### PR TITLE
build: upgrade typescript to 5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-lazy-load-image-component": "^1.6.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "5.0.1",
-    "typescript": "4.1.5",
+    "typescript": "5.0.4",
     "ulid": "^2.3.0",
     "unique-names-generator": "^4.7.1",
     "web-vitals": "^1.0.1"

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -20,6 +20,7 @@ describe('Footer component', () => {
   });
 
   afterAll((): void => {
+    // @ts-ignore
     window.location = location;
   });
   it('should render copyright', () => {

--- a/src/components/Toolbar/Toolbar.test.tsx
+++ b/src/components/Toolbar/Toolbar.test.tsx
@@ -4,7 +4,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Toolbar } from './Toolbar';
-import { useTranslation } from 'react-i18next';
 
 const mockHistoryPush = jest.fn();
 

--- a/src/components/Toolbar/Toolbar.test.tsx
+++ b/src/components/Toolbar/Toolbar.test.tsx
@@ -29,6 +29,7 @@ describe('Toolbar component', () => {
   });
 
   afterAll((): void => {
+    // @ts-ignore
     window.location = location;
   });
   it('should render correct title', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11166,10 +11166,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.1.5:
-  version "4.1.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 ulid@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## What I've done
- upgrade TypeScript to 5.0.4 (because if I upgraded to latest, ESLint will eventually fail)
- fix test cases failed due to upgrading typescript
- remove unused imports

## Why should this be upgraded?
- to upgrade react, react-dom and its types easier
- to upgrade react-router-dom and remove its types easier

## Screenshots

![image](https://github.com/user-attachments/assets/27bb0b12-605b-4e02-ac0f-2856b7804fe8)

![image](https://github.com/user-attachments/assets/b3dea77a-a2bd-469d-bc72-e88708687173)

![image](https://github.com/user-attachments/assets/92b093fa-189a-497d-8e74-f4b5e8ce1497)

![image](https://github.com/user-attachments/assets/75f3065b-57ea-4ec9-9eca-2adfde71135d)

![image](https://github.com/user-attachments/assets/f8c0304d-0e31-4647-b809-41d1b8053452)
