### PR TITLE
fix: apply grid style for player cards to wrap around

### DIFF
--- a/src/components/Players/Players.tsx
+++ b/src/components/Players/Players.tsx
@@ -1,4 +1,4 @@
-import { Grow } from '@material-ui/core';
+import { Grid, Grow } from '@material-ui/core';
 import React from 'react';
 import { Game } from '../../types/game';
 import { Player } from '../../types/player';
@@ -14,9 +14,16 @@ export const Players: React.FC<PlayersProps> = ({ game, players, currentPlayerId
   return (
     <Grow in={true} timeout={800}>
       <div className='PlayersContainer'>
-        {players.map((player: Player) => (
-          <PlayerCard key={player.id} game={game} player={player} currentPlayerId={currentPlayerId} />
-        ))}
+        <Grid container spacing={4} justify='center'>
+          {players.map((player: Player) => (
+            <PlayerCard
+              key={player.id}
+              game={game}
+              player={player}
+              currentPlayerId={currentPlayerId}
+            />
+          ))}
+        </Grid>
       </div>
     </Grow>
   );


### PR DESCRIPTION
apply grid style for player cards to wrap around when there are too many players
Fixes #116 
