### PR TITLE
feat: enables average calc on custom games that has only numeric values

### DIFF
--- a/src/components/Players/CardPicker/CardConfigs.ts
+++ b/src/components/Players/CardPicker/CardConfigs.ts
@@ -121,7 +121,11 @@ export const getRandomEmoji = () => {
 
 export const getCustomCards = (values: string[]) => {
   const customCards: CardConfig[] = customCardsTemplate;
-  values.forEach((value, index) => (customCards[index].displayValue = value));
+  const isEveryCardValueNumber = values.every((value) => !isNaN(Number(value)));
+  values.forEach((value, index) => {
+    customCards[index].displayValue = value;
+    if (isEveryCardValueNumber) customCards[index].value = Number(value);
+  });
 
   return customCards.filter(
     (card) => card.displayValue !== undefined && card.displayValue.trim() !== '',

--- a/src/components/Poker/GameController/GameController.tsx
+++ b/src/components/Poker/GameController/GameController.tsx
@@ -30,6 +30,12 @@ interface GameControllerProps {
   currentPlayerId: string;
 }
 
+const isNumeric = (str: string) => {
+  if (typeof str !== 'string' || str.trim() === '') return false;
+  const num = Number(str);
+  return Number.isFinite(num);
+};
+
 export const GameController: React.FC<GameControllerProps> = ({ game, currentPlayerId }) => {
   const history = useHistory();
   const [showCopiedMessage, setShowCopiedMessage] = useState(false);
@@ -43,6 +49,8 @@ export const GameController: React.FC<GameControllerProps> = ({ game, currentPla
     document.body.removeChild(dummy);
     setShowCopiedMessage(true);
   };
+  const canShowAverageForCustomGameType =
+    game.gameType === GameType.Custom && game.cards.every((card) => isNumeric(card.displayValue));
 
   const leaveGame = () => {
     history.push(`/`);
@@ -67,7 +75,7 @@ export const GameController: React.FC<GameControllerProps> = ({ game, currentPla
                 </Typography>
                 {game.gameType !== GameType.TShirt &&
                   game.gameType !== GameType.TShirtAndNumber &&
-                  game.gameType !== GameType.Custom && (
+                  (game.gameType !== GameType.Custom || canShowAverageForCustomGameType) && (
                     <>
                       <Divider className='GameControllerDivider' orientation='vertical' flexItem />
                       <Typography variant='subtitle1'>Average:</Typography>


### PR DESCRIPTION
Currently it's not possible to get average calc on custom games, even they having only numeric values. This PR solves that problem.