### PR TITLE
fix: show average for custom values even when one player has non numeric values

### DIFF
--- a/src/components/Poker/GameController/GameController.test.tsx
+++ b/src/components/Poker/GameController/GameController.test.tsx
@@ -248,7 +248,7 @@ describe('GameController component', () => {
       expect(screen.getByText('-')).toBeInTheDocument();
     });
 
-    it('shows N/A as average if not all finished players have numeric values', () => {
+    it('shows as average if one finished players have numeric values', () => {
       const playersWithNonNumeric: Player[] = [
         { id: 'abc', name: 'Player1', value: 1, emoji: '☕', status: Status.Finished },
         { id: 'def', name: 'Player2', value: 2, emoji: '😀', status: Status.Finished },
@@ -269,7 +269,7 @@ describe('GameController component', () => {
           players={playersWithNonNumeric}
         />,
       );
-      expect(screen.getByText('N/A')).toBeInTheDocument();
+      expect(screen.getByText('1.00')).toBeInTheDocument();
     });
 
     it('shows average value and info icon when all finished players have numeric values and game is finished', () => {

--- a/src/components/Poker/GameController/GameController.tsx
+++ b/src/components/Poker/GameController/GameController.tsx
@@ -273,9 +273,9 @@ const AverageComponent: React.FC<{ game: Game; players: Player[] }> = ({ game, p
   const gameAverage = getAverage(game, players);
   let average = game.gameStatus === Status.Finished && gameAverage ? gameAverage.toFixed(2) : EMPTY;
 
-  if (!areAllFinishedPlayersDisplayValuesNumeric(game, players)) {
-    average = NOT_APPLICABLE;
-  }
+  // if (!areAllFinishedPlayersDisplayValuesNumeric(game, players)) {
+  //   average = NOT_APPLICABLE;
+  // }
 
   return (
     <>


### PR DESCRIPTION
[ non-numeric valuesfix: show average for custom values even when one player has non numeric values](fix: show average for custom values even when one player has non numeric values)

Fixes: #152 